### PR TITLE
Create credentials root directory even if parent doesn't exist

### DIFF
--- a/subcommands/auth
+++ b/subcommands/auth
@@ -16,7 +16,7 @@ auth-command() {
 
   dokku_log_verbose_quiet "Saving credentials"
 
-  mkdir $LITESTREAM_CREDENTIALS_ROOT
+  mkdir -p $LITESTREAM_CREDENTIALS_ROOT
 
   echo $ACCESS_KEY_ID > $LITESTREAM_CREDENTIALS_ACCESS_KEY_ID
   echo $SECRET_ACCESS_KEY > $LITESTREAM_CREDENTIALS_SECRET_ACCESS_KEY


### PR DESCRIPTION
I encountered an issue when I started `dokku litestream:auth` immediately after installation. The creation of the credentials directory failed because the parent directory did not exist.

Additionally, I believe issue #4 should be fixed because, as the `-p` option for `mkdir` indicates, it does not raise an error if the directory already exists.