### PR TITLE
Fix a few typos in the dokku litestream commands

### DIFF
--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -6,7 +6,7 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 destroy-command() {
   declare desc="Destroy litestream container for the application"
-  local cmd="$PLUGIN_COMMAND_PREFIX:stop" argv=("$@")
+  local cmd="$PLUGIN_COMMAND_PREFIX:destroy" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare APP_NAME="$1"
 

--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -14,7 +14,7 @@ destroy-command() {
   # - validate APP_NAME
 
   local SERVICE_NAME="dokku.$PLUGIN_COMMAND_PREFIX.$APP_NAME"
-  local ID=$(docker ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$(docker ps -a --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   [[ -z $ID ]] && dokku_log_warn "Service is already stopped" && return 0
 
   if [[ -n $ID ]]; then

--- a/subcommands/logs
+++ b/subcommands/logs
@@ -15,7 +15,7 @@ logs-command() {
   # - flag to keep tailing
 
   local SERVICE_NAME="dokku.$PLUGIN_COMMAND_PREFIX.$APP_NAME"
-  local ID=$(docker ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$(docker ps -a --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   [[ -z $ID ]] && dokku_log_info2_quiet "Service is not running" && return 0
 
   if [[ -n $ID ]]; then

--- a/subcommands/restart
+++ b/subcommands/restart
@@ -15,7 +15,7 @@ restart-command() {
   # - reuse litestream:stop and litestream:start?
 
   local SERVICE_NAME="dokku.$PLUGIN_COMMAND_PREFIX.$APP_NAME"
-  local ID=$(docker ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$(docker ps -a --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   [[ -z $ID ]] && dokku_log_warn "Service is already stopped" && return 0
 
   if [[ -n $ID ]]; then

--- a/subcommands/stop
+++ b/subcommands/stop
@@ -14,7 +14,7 @@ stop-command() {
   # - validate APP_NAME
 
   local SERVICE_NAME="dokku.$PLUGIN_COMMAND_PREFIX.$APP_NAME"
-  local ID=$(docker ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$(docker ps -a --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   [[ -z $ID ]] && dokku_log_warn "Service is already stopped" && return 0
 
   if [[ -n $ID ]]; then


### PR DESCRIPTION
- Remove the "-q" flag from "docker ps". Otherwise, the command raises a warning, "Ignoring custom format, because both --format and --quiet are set."
- Fix a typo in the "destroy" command